### PR TITLE
Fix formatted message writing

### DIFF
--- a/auto-wrap-72-char.py
+++ b/auto-wrap-72-char.py
@@ -93,7 +93,8 @@ def main(args):
         formatted_commit_msg = wrapCommitMessageToAMaxWidth(originalCommit)
 
     #Write formatted commit message
-    with codecs.open(message_file, 'wb', encoding='utf-8') as f
+    with codecs.open(message_file, 'wb', encoding='utf-8') as formattedMessageFile:
+        formattedMessageFile.write(formatted_commit_msg)
 
 #
 # End main method


### PR DESCRIPTION
08eafe09227a64acebdf59a7fce4b451eafc6da2 broke writing of the formatted
commit message (and by extension the whole script, because the
offending with statement was lacking a body).
