### PR TITLE
Fix link to git-scm.com book

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ AutoWrap
 
 A Git Commit hook for automatically wrapping all commit messages to 72 characters
 
-Step 1) Copy the script auto-wrap-72-char.py to <Your Git Repo>/.git/hooks.
+Step 1) Copy the script `auto-wrap-72-char.py` to `<Your Git Repo>/.git/hooks`.
 
-Step 2) Add the following lines to <Your Git Repo>/.git/hooks/commit-msg.sample:
+Step 2) Add the following lines to `<Your Git Repo>/.git/hooks/commit-msg.sample`:
 
 ```bash
 if [ "$GITAUTOWRAP" = "true" ]; then
@@ -14,9 +14,9 @@ if [ "$GITAUTOWRAP" = "true" ]; then
 fi
 ```
 
-Step 3) Rename this file to commit-msg to enable the hook.
+Step 3) Rename this file to `commit-msg` to enable the hook.
 
-Step 4) Add an environment variable called GITAUTOWRAP and set its value to "true". 
+Step 4) Add an environment variable called `GITAUTOWRAP` and set its value to `true`.
 
 Voilà! Now your commit messages will be automatically formatted such that no line exceeds 72 characters. Exception: URLs or other long strings that are more than 72 characters wide (since these cannot be broken up)
 
@@ -24,4 +24,4 @@ Existing line breaks are left as-is, as are any lines that are less than 72 char
 
 To find out more about why you may want to format your Git commit messages in this way, check out this blog post: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
-Find a concise introduction to Git hooks here: http://git-scm.com/book/ch7-3.html
+Find a concise introduction to Git hooks here: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks


### PR DESCRIPTION
The current link points to "7.3 Git Tools - Stashing and Cleaning", the relevant chapter moved to 8.3 ("Customizing Git - Git Hooks").

I also made some minor formatting changes.
